### PR TITLE
fix: change docker-compose dependency to developmentOnly

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
-    runtimeOnly 'org.springframework.boot:spring-boot-docker-compose'
+    developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"


### PR DESCRIPTION
배포 환경에서 개발용 docker-compose를 불러오는 오류를 수정했습니다.

spring-boot-docker-compose was set as runtimeOnly, causing the prod container to fail with "No Docker Compose file found in directory '/app/.'" on every startup. Changing to developmentOnly excludes it from the production JAR, fixing the 502 on pcserver.cloud.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 개발 환경 의존성 구성이 업데이트되었습니다. Docker Compose 관련 의존성이 런타임에서 개발 단계로 조정되어 개발 환경의 설정이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->