### PR TITLE
fix: change docker-compose dependency to developmentOnly

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
-    runtimeOnly 'org.springframework.boot:spring-boot-docker-compose'
+    developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"


### PR DESCRIPTION
#17 역병합
배포 환경에서 개발용 docker-compose를 불러오는 오류를 수정했습니다.

spring-boot-docker-compose was set as runtimeOnly, causing the prod container to fail with "No Docker Compose file found in directory '/app/.'" on every startup. Changing to developmentOnly excludes it from the production JAR, fixing the 502 on pcserver.cloud.