### PR TITLE
feat: add logout endpoint with session invalidation

### DIFF
--- a/api/src/main/java/kr/ac/kyonggi/api/auth/AuthController.java
+++ b/api/src/main/java/kr/ac/kyonggi/api/auth/AuthController.java
@@ -1,5 +1,7 @@
 package kr.ac.kyonggi.api.auth;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import kr.ac.kyonggi.api.auth.dto.RegisterRequest;
 import kr.ac.kyonggi.api.auth.dto.UserResponse;
@@ -8,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,5 +31,15 @@ public class AuthController {
     public ResponseEntity<UserResponse> me(@AuthenticationPrincipal UserDetails userDetails) {
         UserResponse response = authApiService.findByEmail(userDetails.getUsername());
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletRequest request) {
+        SecurityContextHolder.clearContext();
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.invalidate();
+        }
+        return ResponseEntity.noContent().build();
     }
 }

--- a/api/src/main/java/kr/ac/kyonggi/api/config/SecurityConfig.java
+++ b/api/src/main/java/kr/ac/kyonggi/api/config/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-                        .requestMatchers("/api/auth/register", "/api/auth/login").permitAll()
+                        .requestMatchers("/api/auth/register", "/api/auth/login", "/api/auth/logout").permitAll()
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects", "/api/projects/*").permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling(ex -> ex

--- a/api/src/test/java/kr/ac/kyonggi/api/auth/controller/AuthControllerTest.java
+++ b/api/src/test/java/kr/ac/kyonggi/api/auth/controller/AuthControllerTest.java
@@ -112,6 +112,22 @@ class AuthControllerTest {
                 .extractingPath("$.email").asString().isEqualTo(EMAIL);
     }
 
+    @Test
+    @WithAnonymousUser
+    @DisplayName("로그아웃 - 미인증 사용자도 204 반환")
+    void logout_unauthenticated() {
+        assertThat(mockMvc.post().uri("/api/auth/logout"))
+                .hasStatus(HttpStatus.NO_CONTENT);
+    }
+
+    @Test
+    @WithMockUser(username = "test@test.com")
+    @DisplayName("로그아웃 - 인증된 사용자 204 반환")
+    void logout_authenticated() {
+        assertThat(mockMvc.post().uri("/api/auth/logout"))
+                .hasStatus(HttpStatus.NO_CONTENT);
+    }
+
     private String toJson(Object obj) throws JsonProcessingException {
         return objectMapper.writeValueAsString(obj);
     }

--- a/api/src/test/java/kr/ac/kyonggi/api/integration/AuthIntegrationTest.java
+++ b/api/src/test/java/kr/ac/kyonggi/api/integration/AuthIntegrationTest.java
@@ -89,6 +89,52 @@ class AuthIntegrationTest {
     }
 
     @Test
+    @DisplayName("로그아웃 후 세션 무효화 확인")
+    void logout_invalidatesSession() {
+        // 1. 회원가입
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        String registerBody = """
+                {
+                  "email": "logout@test.com",
+                  "password": "password123",
+                  "name": "로그아웃테스트"
+                }
+                """;
+        restTemplate.exchange("/api/auth/register", HttpMethod.POST,
+                new HttpEntity<>(registerBody, headers), Map.class);
+
+        // 2. 로그인
+        String loginBody = """
+                {
+                  "email": "logout@test.com",
+                  "password": "password123"
+                }
+                """;
+        ResponseEntity<Map> loginResponse = restTemplate.exchange(
+                "/api/auth/login", HttpMethod.POST,
+                new HttpEntity<>(loginBody, headers), Map.class);
+        List<String> cookies = loginResponse.getHeaders().get(HttpHeaders.SET_COOKIE);
+        String jsessionId = cookies.stream()
+                .filter(c -> c.startsWith("JSESSIONID"))
+                .findFirst().orElseThrow().split(";")[0];
+
+        // 3. 로그아웃
+        HttpHeaders logoutHeaders = new HttpHeaders();
+        logoutHeaders.set(HttpHeaders.COOKIE, jsessionId);
+        ResponseEntity<Void> logoutResponse = restTemplate.exchange(
+                "/api/auth/logout", HttpMethod.POST,
+                new HttpEntity<>(logoutHeaders), Void.class);
+        assertThat(logoutResponse.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        // 4. 로그아웃 후 /me 접근 시 401
+        ResponseEntity<Map> meResponse = restTemplate.exchange(
+                "/api/auth/me", HttpMethod.GET,
+                new HttpEntity<>(logoutHeaders), Map.class);
+        assertThat(meResponse.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
     @DisplayName("중복 이메일 회원가입 시 409 반환")
     void register_duplicateEmail_returns409() {
         HttpHeaders headers = new HttpHeaders();


### PR DESCRIPTION
POST /api/auth/logout 엔드포인트 추가
- SecurityContext 초기화 및 HTTP 세션 무효화
- SecurityConfig에 logout URL permitAll 추가
- 단위 테스트 및 통합 테스트 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
* 로그아웃 기능이 추가되었습니다. 사용자가 명시적으로 로그아웃하여 현재 세션을 종료할 수 있으며, 로그아웃 후에는 인증이 필요한 요청이 거부됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->