### PR TITLE
chore: OpenAI API 키 환경변수 주입 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,7 @@ jobs:
               echo "SPRING_DATASOURCE_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
               echo "DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}" >> .env
               echo "GCLOUD_RW_API_KEY=${{ secrets.GCLOUD_RW_API_KEY }}" >> .env  # grafana alloy api 키
+              echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> .env
               docker compose pull
               docker compose up -d
               docker image prune -f


### PR DESCRIPTION
## 변경 사항

배포 파이프라인(`.github/workflows/deploy.yml`)에서 Azure VM에 `.env` 파일을 생성할 때 `OPENAI_API_KEY` 환경변수를 주입하도록 추가했습니다.

기존의 `GCLOUD_RW_API_KEY` 등 다른 시크릿과 동일한 방식으로 `secrets.OPENAI_API_KEY`를 참조합니다.

> GitHub 저장소 Settings → Secrets에 `OPENAI_API_KEY` 값을 등록해야 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 환경이 업데이트되어 OpenAI API 통합이 활성화되었습니다. 배포 프로세스에서 필요한 환경 설정이 자동으로 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->