### PR TITLE
feat: 500 에러 로그 출력 및 Logback 설정 추가

### DIFF
--- a/api/src/main/java/kr/ac/kyonggi/api/config/filter/MdcFilter.java
+++ b/api/src/main/java/kr/ac/kyonggi/api/config/filter/MdcFilter.java
@@ -1,0 +1,38 @@
+package kr.ac.kyonggi.api.config.filter;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class MdcFilter implements Filter {
+
+    private static final String TRACE_ID = "traceId";
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        String traceId = UUID.randomUUID().toString().substring(0, 8);
+        MDC.put(TRACE_ID, traceId);
+        httpResponse.setHeader("X-Trace-Id", traceId);
+
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            MDC.remove(TRACE_ID);
+        }
+    }
+}

--- a/api/src/main/resources/logback-spring.xml
+++ b/api/src/main/resources/logback-spring.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <property name="LOG_FILE" value="logs/app.log"/>
+    <property name="CONSOLE_LOG_PATTERN" value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr([%X{traceId}]){cyan} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} ${LOG_LEVEL_PATTERN:-%5p} ${PID:- } --- [%t] [%X{traceId}] %-40.40logger{39} : %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+
+    <springProfile name="local,dev">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="prod">
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_FILE}</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>logs/app.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>10MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+                <totalSizeCap>3GB</totalSizeCap>
+            </rollingPolicy>
+            <encoder>
+                <pattern>${FILE_LOG_PATTERN}</pattern>
+                <charset>utf8</charset>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+        </root>
+    </springProfile>
+
+    <logger name="kr.ac.kyonggi" level="DEBUG"/>
+</configuration>

--- a/common/src/main/java/kr/ac/kyonggi/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/kr/ac/kyonggi/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package kr.ac.kyonggi.common.exception;
 
+import jakarta.servlet.http.HttpServletRequest;
 import kr.ac.kyonggi.common.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.validation.FieldError;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.stream.Collectors;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -38,7 +41,8 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleGeneral(Exception ex) {
+    public ResponseEntity<ErrorResponse> handleGeneral(Exception ex, HttpServletRequest request) {
+        log.error("Unhandled Exception occurred at {} {}: ", request.getMethod(), request.getRequestURI(), ex);
         return ResponseEntity
                 .internalServerError()
                 .body(ErrorResponse.of("서버 내부 오류가 발생했습니다.", 500));


### PR DESCRIPTION
## 개요
- 500 에러 발생 시 서버 로그가 남지 않던 문제 해결
- Logback 설정을 추가하여 환경별 로그 관리 체계 구축

## 작업 내용
- 에  적용 및 500 에러 시 스택 트레이스 출력
-  모듈에  설정 추가 (local/dev: 콘솔, prod: 파일/콘솔)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경 사항

* **Chores**
  * 환경별 로깅 설정 추가 — 로컬/개발: 콘솔, 프로덕션: 콘솔+파일 롤링 로그(일일 롤링, 파일 크기 제한, 보존/총 용량 제한 포함)
  * 예외 처리 시 요청 메서드·요청 URI와 함께 오류를 기록하도록 로깅 강화
* **New Features**
  * 모든 요청에 고유한 trace-id 생성 후 로깅에 연결하고 응답 헤더(X-Trace-Id)로 노출하여 추적성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->