### PR TITLE
feat: AI 요약 비동기 전환 (#66)

### DIFF
--- a/api/src/main/java/kr/ac/kyonggi/api/experience/ExperienceApi.java
+++ b/api/src/main/java/kr/ac/kyonggi/api/experience/ExperienceApi.java
@@ -73,6 +73,7 @@ public interface ExperienceApi {
             @ApiResponse(responseCode = "202", description = "요약 시작됨",
                     content = @Content(schema = @Schema(implementation = AiSummaryStatusResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+            @ApiResponse(responseCode = "403", description = "본인 경험만 요약 가능", content = @Content),
             @ApiResponse(responseCode = "404", description = "활동 기록 없음", content = @Content),
             @ApiResponse(responseCode = "409", description = "이미 요약 진행 중", content = @Content)
     })
@@ -92,6 +93,7 @@ public interface ExperienceApi {
             @ApiResponse(responseCode = "200", description = "조회 성공",
                     content = @Content(schema = @Schema(implementation = AiSummaryStatusResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+            @ApiResponse(responseCode = "403", description = "본인 경험만 조회 가능", content = @Content),
             @ApiResponse(responseCode = "404", description = "활동 기록 없음", content = @Content)
     })
     @GetMapping("/{id}/summarize")

--- a/api/src/main/java/kr/ac/kyonggi/api/experience/ExperienceApi.java
+++ b/api/src/main/java/kr/ac/kyonggi/api/experience/ExperienceApi.java
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import kr.ac.kyonggi.api.experience.dto.AiSummaryResponse;
+import kr.ac.kyonggi.api.experience.dto.AiSummaryStatusResponse;
 import kr.ac.kyonggi.api.experience.dto.ExperienceRequest;
 import kr.ac.kyonggi.api.experience.dto.ExperienceResponse;
 import org.springframework.http.ResponseEntity;
@@ -65,18 +65,37 @@ public interface ExperienceApi {
     );
 
     @Operation(
-            summary = "활동 기록 AI 요약",
-            description = "활동 기록을 AI가 분석하여 요약합니다.",
+            summary = "AI 요약 시작 (비동기)",
+            description = "활동 기록 AI 요약을 비동기로 시작합니다. 상태는 GET /{id}/summarize로 폴링합니다.",
             security = @SecurityRequirement(name = "cookieAuth")
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "요약 성공",
-                    content = @Content(schema = @Schema(implementation = AiSummaryResponse.class))),
+            @ApiResponse(responseCode = "202", description = "요약 시작됨",
+                    content = @Content(schema = @Schema(implementation = AiSummaryStatusResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+            @ApiResponse(responseCode = "404", description = "활동 기록 없음", content = @Content),
+            @ApiResponse(responseCode = "409", description = "이미 요약 진행 중", content = @Content)
+    })
+    @PostMapping("/{id}/summarize")
+    ResponseEntity<AiSummaryStatusResponse> startSummarize(
+            @Parameter(description = "활동 기록 ID", example = "1", required = true)
+            @PathVariable Long id,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails
+    );
+
+    @Operation(
+            summary = "AI 요약 상태 조회 (폴링용)",
+            description = "AI 요약 진행 상태를 조회합니다. status: NONE / IN_PROGRESS / COMPLETED / FAILED",
+            security = @SecurityRequirement(name = "cookieAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = AiSummaryStatusResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
             @ApiResponse(responseCode = "404", description = "활동 기록 없음", content = @Content)
     })
-    @PostMapping("/{id}/summarize")
-    ResponseEntity<AiSummaryResponse> summarize(
+    @GetMapping("/{id}/summarize")
+    ResponseEntity<AiSummaryStatusResponse> getSummaryStatus(
             @Parameter(description = "활동 기록 ID", example = "1", required = true)
             @PathVariable Long id,
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails

--- a/api/src/main/java/kr/ac/kyonggi/api/experience/ExperienceApiService.java
+++ b/api/src/main/java/kr/ac/kyonggi/api/experience/ExperienceApiService.java
@@ -15,6 +15,8 @@ import kr.ac.kyonggi.domain.user.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.List;
 
@@ -56,7 +58,7 @@ public class ExperienceApiService {
     @Transactional
     public AiSummaryStatusResponse startSummarize(Long id, String email) {
         User user = userService.getByEmail(email);
-        Experience experience = experienceService.getById(id);
+        Experience experience = experienceService.getByIdWithLock(id);
 
         if (!experience.getUserId().equals(user.getId())) {
             throw new ForbiddenException("본인의 경험 기록만 요약할 수 있습니다.");
@@ -68,7 +70,14 @@ public class ExperienceApiService {
         experience.startSummarizing();
         experienceService.save(experience);
 
-        experienceSummarizeTask.run(experience.getId(), experience.getProjectId());
+        Long experienceId = experience.getId();
+        Long projectId = experience.getProjectId();
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                experienceSummarizeTask.run(experienceId, projectId);
+            }
+        });
 
         return AiSummaryStatusResponse.from(experience);
     }

--- a/api/src/main/java/kr/ac/kyonggi/api/experience/ExperienceApiService.java
+++ b/api/src/main/java/kr/ac/kyonggi/api/experience/ExperienceApiService.java
@@ -1,18 +1,17 @@
 package kr.ac.kyonggi.api.experience;
 
-import kr.ac.kyonggi.api.experience.dto.AiSummaryResponse;
+import kr.ac.kyonggi.api.experience.dto.AiSummaryStatusResponse;
 import kr.ac.kyonggi.api.experience.dto.ExperienceRequest;
 import kr.ac.kyonggi.api.experience.dto.ExperienceResponse;
 import kr.ac.kyonggi.common.exception.ForbiddenException;
+import kr.ac.kyonggi.common.exception.SummarizeAlreadyInProgressException;
 import kr.ac.kyonggi.domain.experience.Experience;
 import kr.ac.kyonggi.domain.experience.ExperienceCreateCommand;
 import kr.ac.kyonggi.domain.experience.ExperienceService;
-import kr.ac.kyonggi.domain.project.Project;
 import kr.ac.kyonggi.domain.project.ProjectMemberRepository;
 import kr.ac.kyonggi.domain.project.ProjectService;
 import kr.ac.kyonggi.domain.user.User;
 import kr.ac.kyonggi.domain.user.UserService;
-import kr.ac.kyonggi.domain.experience.ExperienceSummarizer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,7 +27,7 @@ public class ExperienceApiService {
     private final ProjectService projectService;
     private final UserService userService;
     private final ProjectMemberRepository projectMemberRepository;
-    private final ExperienceSummarizer experienceSummarizer;
+    private final ExperienceSummarizeTask experienceSummarizeTask;
 
     public List<ExperienceResponse> getByProject(Long projectId, String email) {
         User user = userService.getByEmail(email);
@@ -55,29 +54,34 @@ public class ExperienceApiService {
     }
 
     @Transactional
-    public AiSummaryResponse summarize(Long id, String email) {
+    public AiSummaryStatusResponse startSummarize(Long id, String email) {
         User user = userService.getByEmail(email);
         Experience experience = experienceService.getById(id);
 
         if (!experience.getUserId().equals(user.getId())) {
             throw new ForbiddenException("본인의 경험 기록만 요약할 수 있습니다.");
         }
+        if (experience.isSummarizing()) {
+            throw new SummarizeAlreadyInProgressException("이미 요약이 진행 중입니다.");
+        }
 
-        Project project = projectService.getById(experience.getProjectId());
-
-        List<String> keyPoints = experienceSummarizer.generateKeyPoints(
-                project.getTitle(),
-                project.getDescription(),
-                project.getCategory(),
-                project.getSkills(),
-                experience.getContent()
-        );
-        String summary = String.join("\n", keyPoints);
-
-        experience.updateAiSummary(summary);
+        experience.startSummarizing();
         experienceService.save(experience);
 
-        return AiSummaryResponse.from(experience);
+        experienceSummarizeTask.run(experience.getId(), experience.getProjectId());
+
+        return AiSummaryStatusResponse.from(experience);
+    }
+
+    public AiSummaryStatusResponse getSummaryStatus(Long id, String email) {
+        User user = userService.getByEmail(email);
+        Experience experience = experienceService.getById(id);
+
+        if (!experience.getUserId().equals(user.getId())) {
+            throw new ForbiddenException("본인의 경험 기록만 조회할 수 있습니다.");
+        }
+
+        return AiSummaryStatusResponse.from(experience);
     }
 
     private void verifyMembership(Long projectId, Long userId) {

--- a/api/src/main/java/kr/ac/kyonggi/api/experience/ExperienceApiService.java
+++ b/api/src/main/java/kr/ac/kyonggi/api/experience/ExperienceApiService.java
@@ -13,6 +13,7 @@ import kr.ac.kyonggi.domain.project.ProjectService;
 import kr.ac.kyonggi.domain.user.User;
 import kr.ac.kyonggi.domain.user.UserService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -20,6 +21,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -75,7 +77,12 @@ public class ExperienceApiService {
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-                experienceSummarizeTask.run(experienceId, projectId);
+                try {
+                    experienceSummarizeTask.run(experienceId, projectId);
+                } catch (Exception e) {
+                    log.error("비동기 요약 작업 제출 실패 experienceId={}", experienceId, e);
+                    experienceSummarizeTask.markFailed(experienceId);
+                }
             }
         });
 

--- a/api/src/main/java/kr/ac/kyonggi/api/experience/ExperienceController.java
+++ b/api/src/main/java/kr/ac/kyonggi/api/experience/ExperienceController.java
@@ -1,10 +1,11 @@
 package kr.ac.kyonggi.api.experience;
 
 import jakarta.validation.Valid;
-import kr.ac.kyonggi.api.experience.dto.AiSummaryResponse;
+import kr.ac.kyonggi.api.experience.dto.AiSummaryStatusResponse;
 import kr.ac.kyonggi.api.experience.dto.ExperienceRequest;
 import kr.ac.kyonggi.api.experience.dto.ExperienceResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -44,12 +45,21 @@ public class ExperienceController implements ExperienceApi {
     }
 
     @PostMapping("/{id}/summarize")
-    public ResponseEntity<AiSummaryResponse> summarize(
+    public ResponseEntity<AiSummaryStatusResponse> startSummarize(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+                .body(experienceApiService.startSummarize(id, userDetails.getUsername()));
+    }
+
+    @GetMapping("/{id}/summarize")
+    public ResponseEntity<AiSummaryStatusResponse> getSummaryStatus(
             @PathVariable Long id,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
         return ResponseEntity.ok(
-                experienceApiService.summarize(id, userDetails.getUsername())
+                experienceApiService.getSummaryStatus(id, userDetails.getUsername())
         );
     }
 }

--- a/api/src/main/java/kr/ac/kyonggi/api/experience/ExperienceSummarizeTask.java
+++ b/api/src/main/java/kr/ac/kyonggi/api/experience/ExperienceSummarizeTask.java
@@ -22,6 +22,17 @@ public class ExperienceSummarizeTask {
     private final ProjectService projectService;
     private final ExperienceSummarizer experienceSummarizer;
 
+    @Transactional(propagation = org.springframework.transaction.annotation.Propagation.REQUIRES_NEW)
+    public void markFailed(Long experienceId) {
+        try {
+            Experience experience = experienceService.getById(experienceId);
+            experience.failSummarizing();
+            experienceService.save(experience);
+        } catch (Exception e) {
+            log.error("AI 요약 실패 상태 처리 중 오류 experienceId={}", experienceId, e);
+        }
+    }
+
     @Async("asyncExecutor")
     @Transactional
     public void run(Long experienceId, Long projectId) {

--- a/api/src/main/java/kr/ac/kyonggi/api/experience/ExperienceSummarizeTask.java
+++ b/api/src/main/java/kr/ac/kyonggi/api/experience/ExperienceSummarizeTask.java
@@ -1,0 +1,45 @@
+package kr.ac.kyonggi.api.experience;
+
+import kr.ac.kyonggi.domain.experience.Experience;
+import kr.ac.kyonggi.domain.experience.ExperienceService;
+import kr.ac.kyonggi.domain.experience.ExperienceSummarizer;
+import kr.ac.kyonggi.domain.project.Project;
+import kr.ac.kyonggi.domain.project.ProjectService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExperienceSummarizeTask {
+
+    private final ExperienceService experienceService;
+    private final ProjectService projectService;
+    private final ExperienceSummarizer experienceSummarizer;
+
+    @Async("asyncExecutor")
+    @Transactional
+    public void run(Long experienceId, Long projectId) {
+        Experience experience = experienceService.getById(experienceId);
+        try {
+            Project project = projectService.getById(projectId);
+            List<String> keyPoints = experienceSummarizer.generateKeyPoints(
+                    project.getTitle(),
+                    project.getDescription(),
+                    project.getCategory(),
+                    project.getSkills(),
+                    experience.getContent()
+            );
+            experience.completeSummarizing(String.join("\n", keyPoints));
+        } catch (Exception e) {
+            log.error("AI 요약 실패 experienceId={}", experienceId, e);
+            experience.failSummarizing();
+        }
+        experienceService.save(experience);
+    }
+}

--- a/api/src/main/java/kr/ac/kyonggi/api/experience/ExperienceSummarizeTask.java
+++ b/api/src/main/java/kr/ac/kyonggi/api/experience/ExperienceSummarizeTask.java
@@ -25,7 +25,13 @@ public class ExperienceSummarizeTask {
     @Async("asyncExecutor")
     @Transactional
     public void run(Long experienceId, Long projectId) {
-        Experience experience = experienceService.getById(experienceId);
+        Experience experience;
+        try {
+            experience = experienceService.getById(experienceId);
+        } catch (Exception e) {
+            log.error("Experience 조회 실패 experienceId={}", experienceId, e);
+            return;
+        }
         try {
             Project project = projectService.getById(projectId);
             List<String> keyPoints = experienceSummarizer.generateKeyPoints(

--- a/api/src/main/java/kr/ac/kyonggi/api/experience/dto/AiSummaryStatusResponse.java
+++ b/api/src/main/java/kr/ac/kyonggi/api/experience/dto/AiSummaryStatusResponse.java
@@ -1,0 +1,18 @@
+package kr.ac.kyonggi.api.experience.dto;
+
+import kr.ac.kyonggi.domain.experience.AiSummaryStatus;
+import kr.ac.kyonggi.domain.experience.Experience;
+
+public record AiSummaryStatusResponse(
+        Long id,
+        AiSummaryStatus status,
+        String aiSummary
+) {
+    public static AiSummaryStatusResponse from(Experience experience) {
+        return new AiSummaryStatusResponse(
+                experience.getId(),
+                experience.getAiSummaryStatus(),
+                experience.getAiSummary()
+        );
+    }
+}

--- a/api/src/test/java/kr/ac/kyonggi/api/experience/ExperienceApiServiceTest.java
+++ b/api/src/test/java/kr/ac/kyonggi/api/experience/ExperienceApiServiceTest.java
@@ -1,9 +1,12 @@
 package kr.ac.kyonggi.api.experience;
 
 import kr.ac.kyonggi.api.experience.dto.AiSummaryResponse;
+import kr.ac.kyonggi.api.experience.dto.AiSummaryStatusResponse;
 import kr.ac.kyonggi.api.experience.dto.ExperienceRequest;
 import kr.ac.kyonggi.api.experience.dto.ExperienceResponse;
 import kr.ac.kyonggi.common.exception.ForbiddenException;
+import kr.ac.kyonggi.common.exception.SummarizeAlreadyInProgressException;
+import kr.ac.kyonggi.domain.experience.AiSummaryStatus;
 import kr.ac.kyonggi.domain.experience.Experience;
 import kr.ac.kyonggi.domain.experience.ExperienceCreateCommand;
 import kr.ac.kyonggi.domain.experience.ExperienceService;
@@ -14,7 +17,6 @@ import kr.ac.kyonggi.domain.project.ProjectService;
 import kr.ac.kyonggi.domain.user.User;
 import kr.ac.kyonggi.domain.user.UserCreateCommand;
 import kr.ac.kyonggi.domain.user.UserService;
-import kr.ac.kyonggi.domain.experience.ExperienceSummarizer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class ExperienceApiServiceTest {
@@ -39,7 +42,7 @@ class ExperienceApiServiceTest {
     @Mock private ProjectService projectService;
     @Mock private UserService userService;
     @Mock private ProjectMemberRepository projectMemberRepository;
-    @Mock private ExperienceSummarizer experienceSummarizer;
+    @Mock private ExperienceSummarizeTask experienceSummarizeTask;
 
     @InjectMocks
     private ExperienceApiService experienceApiService;
@@ -134,39 +137,61 @@ class ExperienceApiServiceTest {
                 .isInstanceOf(ForbiddenException.class);
     }
 
-    // ── summarize() ───────────────────────────────────────────────────
+
+    // ── startSummarize() ─────────────────────────────────────────────
 
     @Test
-    @DisplayName("summarize()는 본인 경험에 AI 키포인트를 생성하고 AiSummaryResponse를 반환한다")
-    void summarize_generatesAiSummary_forOwner() {
+    @DisplayName("startSummarize()는 상태가 IN_PROGRESS면 SummarizeAlreadyInProgressException을 던진다")
+    void startSummarize_whenAlreadyInProgress_throwsConflict() {
+        experience.startSummarizing();
+
         given(userService.getByEmail(EMAIL)).willReturn(user);
         given(experienceService.getById(100L)).willReturn(experience);
-        given(projectService.getById(PROJECT_ID)).willReturn(project);
-        given(experienceSummarizer.generateKeyPoints(
-                project.getTitle(),
-                project.getDescription(),
-                project.getCategory(),
-                project.getSkills(),
-                experience.getContent()
-        )).willReturn(List.of("JWT 기반 로그인 인증 시스템 구축", "Spring Security 적용"));
-        given(experienceService.save(any(Experience.class))).willAnswer(inv -> inv.getArgument(0));
 
-        AiSummaryResponse result = experienceApiService.summarize(100L, EMAIL);
-
-        assertThat(result.id()).isEqualTo(100L);
-        assertThat(result.aiSummary()).isEqualTo("JWT 기반 로그인 인증 시스템 구축\nSpring Security 적용");
+        assertThatThrownBy(() -> experienceApiService.startSummarize(100L, EMAIL))
+                .isInstanceOf(SummarizeAlreadyInProgressException.class);
     }
 
     @Test
-    @DisplayName("summarize()는 본인 경험이 아니면 ForbiddenException을 던진다")
-    void summarize_throwsForbiddenException_forNonOwner() {
+    @DisplayName("startSummarize()는 상태를 IN_PROGRESS로 변경하고 비동기 작업을 시작한다")
+    void startSummarize_success_setsInProgressAndStartsAsync() {
+        given(userService.getByEmail(EMAIL)).willReturn(user);
+        given(experienceService.getById(100L)).willReturn(experience);
+        given(experienceService.save(any(Experience.class))).willAnswer(inv -> inv.getArgument(0));
+
+        AiSummaryStatusResponse result = experienceApiService.startSummarize(100L, EMAIL);
+
+        assertThat(result.status()).isEqualTo(AiSummaryStatus.IN_PROGRESS);
+        verify(experienceSummarizeTask).run(100L, PROJECT_ID);
+    }
+
+    @Test
+    @DisplayName("startSummarize()는 본인 경험이 아니면 ForbiddenException을 던진다")
+    void startSummarize_throwsForbiddenException_forNonOwner() {
         User other = User.create(new UserCreateCommand("other@test.com", "pw", "타인", null));
         ReflectionTestUtils.setField(other, "id", 99L);
 
         given(userService.getByEmail("other@test.com")).willReturn(other);
         given(experienceService.getById(100L)).willReturn(experience);
 
-        assertThatThrownBy(() -> experienceApiService.summarize(100L, "other@test.com"))
+        assertThatThrownBy(() -> experienceApiService.startSummarize(100L, "other@test.com"))
                 .isInstanceOf(ForbiddenException.class);
+    }
+
+    // ── getSummaryStatus() ────────────────────────────────────────────
+
+    @Test
+    @DisplayName("getSummaryStatus()는 현재 요약 상태를 반환한다")
+    void getSummaryStatus_returnsCurrentStatus() {
+        experience.startSummarizing();
+        experience.completeSummarizing("포인트1\n포인트2");
+
+        given(userService.getByEmail(EMAIL)).willReturn(user);
+        given(experienceService.getById(100L)).willReturn(experience);
+
+        AiSummaryStatusResponse result = experienceApiService.getSummaryStatus(100L, EMAIL);
+
+        assertThat(result.status()).isEqualTo(AiSummaryStatus.COMPLETED);
+        assertThat(result.aiSummary()).isEqualTo("포인트1\n포인트2");
     }
 }

--- a/api/src/test/java/kr/ac/kyonggi/api/experience/ExperienceApiServiceTest.java
+++ b/api/src/test/java/kr/ac/kyonggi/api/experience/ExperienceApiServiceTest.java
@@ -31,6 +31,9 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -146,23 +149,32 @@ class ExperienceApiServiceTest {
         experience.startSummarizing();
 
         given(userService.getByEmail(EMAIL)).willReturn(user);
-        given(experienceService.getById(100L)).willReturn(experience);
+        given(experienceService.getByIdWithLock(100L)).willReturn(experience);
 
         assertThatThrownBy(() -> experienceApiService.startSummarize(100L, EMAIL))
                 .isInstanceOf(SummarizeAlreadyInProgressException.class);
     }
 
     @Test
-    @DisplayName("startSummarize()는 상태를 IN_PROGRESS로 변경하고 비동기 작업을 시작한다")
+    @DisplayName("startSummarize()는 상태를 IN_PROGRESS로 변경하고 트랜잭션 커밋 후 비동기 작업을 시작한다")
     void startSummarize_success_setsInProgressAndStartsAsync() {
-        given(userService.getByEmail(EMAIL)).willReturn(user);
-        given(experienceService.getById(100L)).willReturn(experience);
-        given(experienceService.save(any(Experience.class))).willAnswer(inv -> inv.getArgument(0));
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            given(userService.getByEmail(EMAIL)).willReturn(user);
+            given(experienceService.getByIdWithLock(100L)).willReturn(experience);
+            given(experienceService.save(any(Experience.class))).willAnswer(inv -> inv.getArgument(0));
 
-        AiSummaryStatusResponse result = experienceApiService.startSummarize(100L, EMAIL);
+            AiSummaryStatusResponse result = experienceApiService.startSummarize(100L, EMAIL);
 
-        assertThat(result.status()).isEqualTo(AiSummaryStatus.IN_PROGRESS);
-        verify(experienceSummarizeTask).run(100L, PROJECT_ID);
+            assertThat(result.status()).isEqualTo(AiSummaryStatus.IN_PROGRESS);
+
+            TransactionSynchronizationManager.getSynchronizations()
+                    .forEach(TransactionSynchronization::afterCommit);
+
+            verify(experienceSummarizeTask).run(100L, PROJECT_ID);
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
     }
 
     @Test
@@ -172,7 +184,7 @@ class ExperienceApiServiceTest {
         ReflectionTestUtils.setField(other, "id", 99L);
 
         given(userService.getByEmail("other@test.com")).willReturn(other);
-        given(experienceService.getById(100L)).willReturn(experience);
+        given(experienceService.getByIdWithLock(100L)).willReturn(experience);
 
         assertThatThrownBy(() -> experienceApiService.startSummarize(100L, "other@test.com"))
                 .isInstanceOf(ForbiddenException.class);

--- a/api/src/test/java/kr/ac/kyonggi/api/experience/ExperienceControllerTest.java
+++ b/api/src/test/java/kr/ac/kyonggi/api/experience/ExperienceControllerTest.java
@@ -2,8 +2,9 @@ package kr.ac.kyonggi.api.experience;
 
 import kr.ac.kyonggi.api.auth.AuthApiService;
 import kr.ac.kyonggi.api.config.SecurityConfig;
-import kr.ac.kyonggi.api.experience.dto.AiSummaryResponse;
+import kr.ac.kyonggi.api.experience.dto.AiSummaryStatusResponse;
 import kr.ac.kyonggi.api.experience.dto.ExperienceResponse;
+import kr.ac.kyonggi.domain.experience.AiSummaryStatus;
 import kr.ac.kyonggi.api.security.CustomUserDetailsService;
 import kr.ac.kyonggi.api.security.LoginSuccessHandler;
 import kr.ac.kyonggi.common.exception.ExperienceNotFoundException;
@@ -145,22 +146,33 @@ class ExperienceControllerTest {
 
     @Test
     @WithMockUser(username = EMAIL)
-    @DisplayName("POST /api/experiences/{id}/summarize - 본인 경험이면 200 및 AI 요약 반환")
-    void summarize_owner_returns200WithAiSummary() {
-        when(experienceApiService.summarize(eq(100L), eq(EMAIL)))
-                .thenReturn(new AiSummaryResponse(100L, "JWT 기반 로그인 인증 시스템 구축"));
+    @DisplayName("POST /api/experiences/{id}/summarize - 요약 시작 성공 시 202 반환")
+    void startSummarize_owner_returns202() {
+        when(experienceApiService.startSummarize(eq(100L), eq(EMAIL)))
+                .thenReturn(new AiSummaryStatusResponse(100L, AiSummaryStatus.IN_PROGRESS, null));
 
         assertThat(mockMvc.post().uri("/api/experiences/100/summarize"))
-                .hasStatus(HttpStatus.OK)
+                .hasStatus(HttpStatus.ACCEPTED)
                 .bodyJson()
-                .extractingPath("$.aiSummary").asString().isEqualTo("JWT 기반 로그인 인증 시스템 구축");
+                .extractingPath("$.status").asString().isEqualTo("IN_PROGRESS");
+    }
+
+    @Test
+    @WithMockUser(username = EMAIL)
+    @DisplayName("POST /api/experiences/{id}/summarize - 이미 진행 중이면 409 반환")
+    void startSummarize_alreadyInProgress_returns409() {
+        when(experienceApiService.startSummarize(eq(100L), eq(EMAIL)))
+                .thenThrow(new kr.ac.kyonggi.common.exception.SummarizeAlreadyInProgressException("이미 요약이 진행 중입니다."));
+
+        assertThat(mockMvc.post().uri("/api/experiences/100/summarize"))
+                .hasStatus(HttpStatus.CONFLICT);
     }
 
     @Test
     @WithMockUser(username = EMAIL)
     @DisplayName("POST /api/experiences/{id}/summarize - 본인 경험이 아니면 403 반환")
-    void summarize_nonOwner_returns403() {
-        when(experienceApiService.summarize(eq(100L), eq(EMAIL)))
+    void startSummarize_nonOwner_returns403() {
+        when(experienceApiService.startSummarize(eq(100L), eq(EMAIL)))
                 .thenThrow(new ForbiddenException("본인의 경험 기록만 요약할 수 있습니다."));
 
         assertThat(mockMvc.post().uri("/api/experiences/100/summarize"))
@@ -169,9 +181,22 @@ class ExperienceControllerTest {
 
     @Test
     @WithMockUser(username = EMAIL)
+    @DisplayName("GET /api/experiences/{id}/summarize - 요약 상태 조회 성공 시 200 반환")
+    void getSummaryStatus_returns200() {
+        when(experienceApiService.getSummaryStatus(eq(100L), eq(EMAIL)))
+                .thenReturn(new AiSummaryStatusResponse(100L, AiSummaryStatus.COMPLETED, "포인트1\n포인트2"));
+
+        assertThat(mockMvc.get().uri("/api/experiences/100/summarize"))
+                .hasStatus(HttpStatus.OK)
+                .bodyJson()
+                .extractingPath("$.status").asString().isEqualTo("COMPLETED");
+    }
+
+    @Test
+    @WithMockUser(username = EMAIL)
     @DisplayName("POST /api/experiences/{id}/summarize - 경험이 없으면 404 반환")
-    void summarize_notFound_returns404() {
-        when(experienceApiService.summarize(eq(999L), eq(EMAIL)))
+    void startSummarize_notFound_returns404() {
+        when(experienceApiService.startSummarize(eq(999L), eq(EMAIL)))
                 .thenThrow(new ExperienceNotFoundException("경험 기록을 찾을 수 없습니다: 999"));
 
         assertThat(mockMvc.post().uri("/api/experiences/999/summarize"))

--- a/common/src/main/java/kr/ac/kyonggi/common/exception/SummarizeAlreadyInProgressException.java
+++ b/common/src/main/java/kr/ac/kyonggi/common/exception/SummarizeAlreadyInProgressException.java
@@ -1,0 +1,10 @@
+package kr.ac.kyonggi.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class SummarizeAlreadyInProgressException extends BusinessException {
+
+    public SummarizeAlreadyInProgressException(String message) {
+        super(message, HttpStatus.CONFLICT);
+    }
+}

--- a/db/migrations/V20260402151005.sql
+++ b/db/migrations/V20260402151005.sql
@@ -1,0 +1,3 @@
+-- experiences 테이블에 ai_summary_status 컬럼 추가
+ALTER TABLE experiences
+    ADD COLUMN ai_summary_status VARCHAR(20) NOT NULL DEFAULT 'NONE';

--- a/domain/src/main/java/kr/ac/kyonggi/domain/experience/AiSummaryStatus.java
+++ b/domain/src/main/java/kr/ac/kyonggi/domain/experience/AiSummaryStatus.java
@@ -1,0 +1,8 @@
+package kr.ac.kyonggi.domain.experience;
+
+public enum AiSummaryStatus {
+    NONE,
+    IN_PROGRESS,
+    COMPLETED,
+    FAILED
+}

--- a/domain/src/main/java/kr/ac/kyonggi/domain/experience/Experience.java
+++ b/domain/src/main/java/kr/ac/kyonggi/domain/experience/Experience.java
@@ -3,6 +3,8 @@ package kr.ac.kyonggi.domain.experience;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -42,6 +44,10 @@ public class Experience {
     @Column(columnDefinition = "TEXT")
     private String aiSummary;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AiSummaryStatus aiSummaryStatus = AiSummaryStatus.NONE;
+
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt;
@@ -62,5 +68,22 @@ public class Experience {
 
     public void updateAiSummary(String summary) {
         this.aiSummary = summary;
+    }
+
+    public void startSummarizing() {
+        this.aiSummaryStatus = AiSummaryStatus.IN_PROGRESS;
+    }
+
+    public void completeSummarizing(String summary) {
+        this.aiSummary = summary;
+        this.aiSummaryStatus = AiSummaryStatus.COMPLETED;
+    }
+
+    public void failSummarizing() {
+        this.aiSummaryStatus = AiSummaryStatus.FAILED;
+    }
+
+    public boolean isSummarizing() {
+        return this.aiSummaryStatus == AiSummaryStatus.IN_PROGRESS;
     }
 }

--- a/domain/src/main/java/kr/ac/kyonggi/domain/experience/ExperienceRepository.java
+++ b/domain/src/main/java/kr/ac/kyonggi/domain/experience/ExperienceRepository.java
@@ -1,6 +1,9 @@
 package kr.ac.kyonggi.domain.experience;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +13,8 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long> {
     Optional<Experience> findByProjectIdAndUserId(Long projectId, Long userId);
 
     List<Experience> findByProjectIdInAndUserId(List<Long> projectIds, Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT e FROM Experience e WHERE e.id = :id")
+    Optional<Experience> findByIdWithLock(Long id);
 }

--- a/domain/src/main/java/kr/ac/kyonggi/domain/experience/ExperienceService.java
+++ b/domain/src/main/java/kr/ac/kyonggi/domain/experience/ExperienceService.java
@@ -12,6 +12,8 @@ public interface ExperienceService {
 
     Experience getById(Long id);
 
+    Experience getByIdWithLock(Long id);
+
     Experience save(Experience experience);
 
     Map<Long, Experience> findByProjectIdsAndUserId(List<Long> projectIds, Long userId);

--- a/domain/src/main/java/kr/ac/kyonggi/domain/experience/ExperienceServiceImpl.java
+++ b/domain/src/main/java/kr/ac/kyonggi/domain/experience/ExperienceServiceImpl.java
@@ -37,6 +37,13 @@ public class ExperienceServiceImpl implements ExperienceService {
 
     @Override
     @Transactional
+    public Experience getByIdWithLock(Long id) {
+        return experienceRepository.findByIdWithLock(id)
+                .orElseThrow(() -> new ExperienceNotFoundException("경험 기록을 찾을 수 없습니다: " + id));
+    }
+
+    @Override
+    @Transactional
     public Experience save(Experience experience) {
         return experienceRepository.save(experience);
     }

--- a/domain/src/test/java/kr/ac/kyonggi/domain/experience/ExperienceTest.java
+++ b/domain/src/test/java/kr/ac/kyonggi/domain/experience/ExperienceTest.java
@@ -51,4 +51,49 @@ class ExperienceTest {
 
         assertThat(experience.getAiSummary()).isEqualTo("JWT를 활용한 보안 인증 시스템 구축");
     }
+
+    @Test
+    @DisplayName("create() 직후 aiSummaryStatus는 NONE이다")
+    void create_initialAiSummaryStatusIsNone() {
+        Experience experience = Experience.create(
+                new ExperienceCreateCommand(USER_ID, PROJECT_ID, "내용"));
+
+        assertThat(experience.getAiSummaryStatus()).isEqualTo(AiSummaryStatus.NONE);
+    }
+
+    @Test
+    @DisplayName("startSummarizing()을 호출하면 상태가 IN_PROGRESS로 변경된다")
+    void startSummarizing_setsStatusToInProgress() {
+        Experience experience = Experience.create(
+                new ExperienceCreateCommand(USER_ID, PROJECT_ID, "내용"));
+
+        experience.startSummarizing();
+
+        assertThat(experience.getAiSummaryStatus()).isEqualTo(AiSummaryStatus.IN_PROGRESS);
+    }
+
+    @Test
+    @DisplayName("completeSummarizing()을 호출하면 상태가 COMPLETED로 변경되고 요약이 저장된다")
+    void completeSummarizing_setsStatusAndSummary() {
+        Experience experience = Experience.create(
+                new ExperienceCreateCommand(USER_ID, PROJECT_ID, "내용"));
+        experience.startSummarizing();
+
+        experience.completeSummarizing("포인트1\n포인트2");
+
+        assertThat(experience.getAiSummaryStatus()).isEqualTo(AiSummaryStatus.COMPLETED);
+        assertThat(experience.getAiSummary()).isEqualTo("포인트1\n포인트2");
+    }
+
+    @Test
+    @DisplayName("failSummarizing()을 호출하면 상태가 FAILED로 변경된다")
+    void failSummarizing_setsStatusToFailed() {
+        Experience experience = Experience.create(
+                new ExperienceCreateCommand(USER_ID, PROJECT_ID, "내용"));
+        experience.startSummarizing();
+
+        experience.failSummarizing();
+
+        assertThat(experience.getAiSummaryStatus()).isEqualTo(AiSummaryStatus.FAILED);
+    }
 }


### PR DESCRIPTION
## 관련 이슈
closes #66

## 변경 내용

### 비동기 전환
- `POST /api/experiences/{id}/summarize` → **202 Accepted** 즉시 반환
- AI 호출은 `ExperienceSummarizeTask`(`@Async`)가 백그라운드에서 처리

### 폴링 엔드포인트 추가
- `GET /api/experiences/{id}/summarize` → 현재 요약 상태 반환
- `status`: `NONE` / `IN_PROGRESS` / `COMPLETED` / `FAILED`

### 중복 실행 방지
- `IN_PROGRESS` 상태에서 재요청 시 **409 Conflict** 반환

### DB 변경
- `experiences.ai_summary_status VARCHAR(20) NOT NULL DEFAULT 'NONE'` 컬럼 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * AI 요약이 비동기화되어 요약 시작 시 202 응답을 반환하고, 별도 상태 확인 GET 엔드포인트로 진행 상황(NONE/IN_PROGRESS/COMPLETED/FAILED)과 결과를 조회할 수 있습니다.
* **버그 수정/안정성**
  * 이미 진행 중인 요약에 대한 중복 요청은 409로 차단되며, 소유자 검증으로 권한 없는 요청은 403으로 처리됩니다.
* **데이터베이스**
  * 경험 엔티티에 요약 상태 컬럼(ai_summary_status)이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->