### PR TITLE
fix: 프로젝트 생성 시 작성자 이중 멤버 등록 및 currentMemberCount 미반영 버그 수정

### DIFF
--- a/api/src/main/java/kr/ac/kyonggi/api/project/ProjectApiService.java
+++ b/api/src/main/java/kr/ac/kyonggi/api/project/ProjectApiService.java
@@ -63,7 +63,6 @@ public class ProjectApiService {
                 author.getId()));
 
         Project saved = projectService.create(project);
-        projectService.apply(saved.getId(), author.getId());
         eventPublisher.publishEvent(new NotificationCreatedEvent(
                 author.getId(), "\"" + saved.getTitle() + "\" 프로젝트에 참가했습니다."));
 

--- a/api/src/test/java/kr/ac/kyonggi/api/project/ProjectServiceImplTest.java
+++ b/api/src/test/java/kr/ac/kyonggi/api/project/ProjectServiceImplTest.java
@@ -86,6 +86,22 @@ class ProjectServiceImplTest {
         assertThat(projectMemberRepository.existsByProjectIdAndUserId(saved.getId(), 1L)).isTrue();
     }
 
+    @Test
+    @DisplayName("create()는 작성자를 멤버로 등록하고 currentMemberCount를 1로 설정한다")
+    void create_setsCurrentMemberCountToOne() {
+        Project newProject = Project.create(new ProjectCreateCommand(
+                "새 프로젝트", "설명", "프론트엔드", List.of("React"), 3,
+                LocalDate.of(2026, 12, 31), 1L
+        ));
+
+        Project saved = projectService.create(newProject);
+        em.flush();
+        em.clear();
+
+        Project found = projectRepository.findById(saved.getId()).orElseThrow();
+        assertThat(found.getCurrentMemberCount()).isEqualTo(1);
+    }
+
     // ── getById() ─────────────────────────────────────────────────────
 
     @Test

--- a/domain/src/main/java/kr/ac/kyonggi/domain/project/ProjectServiceImpl.java
+++ b/domain/src/main/java/kr/ac/kyonggi/domain/project/ProjectServiceImpl.java
@@ -24,9 +24,9 @@ public class ProjectServiceImpl implements ProjectService {
     @Override
     @Transactional
     public Project create(Project project) {
+        project.addMember();
         Project saved = projectRepository.save(project);
-        projectMemberRepository.save
-                (ProjectMember.of(new ProjectMemberCreateCommand(saved.getId(), saved.getAuthorId())));
+        projectMemberRepository.save(ProjectMember.of(new ProjectMemberCreateCommand(saved.getId(), saved.getAuthorId())));
         return saved;
     }
 


### PR DESCRIPTION
## 원인

`ProjectApiService.createProject()`가 `projectService.create()` 호출 후 `projectService.apply()`를 추가로 호출하는 구조였음.

그런데 `ProjectServiceImpl.create()` 내부에서 이미 작성자를 `ProjectMember`로 저장하고 있어, 곧바로 호출되는 `apply()`의 중복 체크(`existsByProjectIdAndUserId`)에 걸려 `AlreadyAppliedException` 발생.

또한 `create()`에서 `addMember()`를 호출하지 않아 `currentMemberCount`가 0으로 남는 2차 버그도 함께 존재했음.

## 수정 내용

- `ProjectServiceImpl.create()`: `project.addMember()` 추가 → 작성자 등록 시 카운트 반영
- `ProjectApiService.createProject()`: `projectService.apply()` 호출 제거 → 도메인 불변 규칙을 `domain` 레이어에서만 처리

## 아키텍처 근거

"작성자는 프로젝트 생성 시 자동으로 멤버가 된다"는 도메인 불변 규칙이므로 `domain` 레이어의 `create()`에서 일원화해야 하며, `api` 레이어(Facade)가 이를 `apply()` 호출로 재구현하는 것은 책임 분리 위반.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 프로젝트 생성 시 작성자가 자동으로 프로젝트의 멤버로 포함되도록 개선했습니다.

* **테스트**
  * 프로젝트 생성 후 멤버 수가 정확하게 설정되는지 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->