### PR TITLE
fix: 프로젝트 참가 멤버 연락처 미표시 및 회원가입 전화번호 추가     

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ docker/redis/data/
 
 ### Claude Code ###
 .claude/settings.local.json
+
+### Logs ###
+**/logs/

--- a/api/src/main/java/kr/ac/kyonggi/api/auth/AuthApiService.java
+++ b/api/src/main/java/kr/ac/kyonggi/api/auth/AuthApiService.java
@@ -23,7 +23,7 @@ public class AuthApiService {
         }
 
         User user = User.create(new UserCreateCommand(
-                request.email(), passwordEncoder.encode(request.password()), request.name(), null));
+                request.email(), passwordEncoder.encode(request.password()), request.name(), null, request.phone()));
 
         User saved = userService.register(user);
         return UserResponse.from(saved);

--- a/api/src/main/java/kr/ac/kyonggi/api/auth/dto/RegisterRequest.java
+++ b/api/src/main/java/kr/ac/kyonggi/api/auth/dto/RegisterRequest.java
@@ -20,6 +20,9 @@ public record RegisterRequest(
         @NotBlank(message = "이름을 입력해주세요.")
         @Size(min = 2, max = 50, message = "이름은 2자 이상 50자 이하여야 합니다.")
         @Schema(description = "이름 (2~50자)", example = "홍길동")
-        String name
+        String name,
+
+        @Schema(description = "전화번호", example = "010-1234-5678")
+        String phone
 
 ) {}

--- a/api/src/main/java/kr/ac/kyonggi/api/project/dto/ParticipantResponse.java
+++ b/api/src/main/java/kr/ac/kyonggi/api/project/dto/ParticipantResponse.java
@@ -14,6 +14,12 @@ public record ParticipantResponse(
         @Schema(description = "이름", example = "홍길동")
         String name,
 
+        @Schema(description = "이메일", example = "hong@example.com")
+        String email,
+
+        @Schema(description = "전화번호", example = "010-1234-5678")
+        String phone,
+
         @Schema(description = "프로필 이미지 URL", example = "https://example.com/image.png")
         String profileImage,
 
@@ -31,6 +37,8 @@ public record ParticipantResponse(
         return new ParticipantResponse(
                 user.getId(),
                 user.getName(),
+                user.getEmail(),
+                user.getPhone(),
                 user.getProfileImage(),
                 user.getGithub(),
                 user.getBlog(),

--- a/api/src/test/java/kr/ac/kyonggi/api/auth/controller/AuthControllerTest.java
+++ b/api/src/test/java/kr/ac/kyonggi/api/auth/controller/AuthControllerTest.java
@@ -56,7 +56,7 @@ class AuthControllerTest {
 
         assertThat(mockMvc.post().uri("/api/auth/register")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(new RegisterRequest(EMAIL, PASSWORD, NAME))))
+                .content(toJson(new RegisterRequest(EMAIL, PASSWORD, NAME, null))))
                 .hasStatus(HttpStatus.CREATED)
                 .bodyJson()
                 .extractingPath("$.email").asString().isEqualTo(EMAIL);
@@ -70,7 +70,7 @@ class AuthControllerTest {
 
         assertThat(mockMvc.post().uri("/api/auth/register")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(new RegisterRequest(EMAIL, PASSWORD, NAME))))
+                .content(toJson(new RegisterRequest(EMAIL, PASSWORD, NAME, null))))
                 .hasStatus(HttpStatus.CONFLICT);
     }
 
@@ -79,7 +79,7 @@ class AuthControllerTest {
     void register_invalidEmail() throws JsonProcessingException {
         assertThat(mockMvc.post().uri("/api/auth/register")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(new RegisterRequest("not-an-email", PASSWORD, NAME))))
+                .content(toJson(new RegisterRequest("not-an-email", PASSWORD, NAME, null))))
                 .hasStatus(HttpStatus.BAD_REQUEST);
     }
 
@@ -88,7 +88,7 @@ class AuthControllerTest {
     void register_shortPassword() throws JsonProcessingException {
         assertThat(mockMvc.post().uri("/api/auth/register")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(new RegisterRequest(EMAIL, "short", NAME))))
+                .content(toJson(new RegisterRequest(EMAIL, "short", NAME, null))))
                 .hasStatus(HttpStatus.BAD_REQUEST);
     }
 

--- a/api/src/test/java/kr/ac/kyonggi/api/auth/service/AuthApiServiceTest.java
+++ b/api/src/test/java/kr/ac/kyonggi/api/auth/service/AuthApiServiceTest.java
@@ -33,7 +33,7 @@ class AuthApiServiceTest {
     @Test
     @DisplayName("신규 이메일로 회원가입 성공")
     void register_newEmail_success() {
-        RegisterRequest request = new RegisterRequest("test@test.com", "password123", "홍길동");
+        RegisterRequest request = new RegisterRequest("test@test.com", "password123", "홍길동", null);
 
         UserResponse response = authApiService.register(request);
 
@@ -44,7 +44,7 @@ class AuthApiServiceTest {
     @Test
     @DisplayName("중복 이메일로 회원가입 시 UserAlreadyExistsException 발생")
     void register_duplicateEmail_throwsException() {
-        RegisterRequest request = new RegisterRequest("test@test.com", "password123", "홍길동");
+        RegisterRequest request = new RegisterRequest("test@test.com", "password123", "홍길동", null);
         authApiService.register(request);
 
         assertThatThrownBy(() -> authApiService.register(request))
@@ -54,7 +54,7 @@ class AuthApiServiceTest {
     @Test
     @DisplayName("회원가입 시 비밀번호는 단방향 암호화되어 저장됨")
     void register_passwordIsEncoded() {
-        authApiService.register(new RegisterRequest("test@test.com", "password123", "홍길동"));
+        authApiService.register(new RegisterRequest("test@test.com", "password123", "홍길동", null));
 
         String storedPassword = userRepository.findByEmail("test@test.com").orElseThrow().getPassword();
 
@@ -65,7 +65,7 @@ class AuthApiServiceTest {
     @Test
     @DisplayName("이메일로 UserResponse 조회")
     void findByEmail_returnsUserResponse() {
-        authApiService.register(new RegisterRequest("test@test.com", "password123", "홍길동"));
+        authApiService.register(new RegisterRequest("test@test.com", "password123", "홍길동", null));
 
         UserResponse response = authApiService.findByEmail("test@test.com");
 

--- a/api/src/test/java/kr/ac/kyonggi/api/auth/service/UserServiceImplTest.java
+++ b/api/src/test/java/kr/ac/kyonggi/api/auth/service/UserServiceImplTest.java
@@ -28,7 +28,7 @@ class UserServiceImplTest {
     private UserService userService;
 
     private User buildUser(String email) {
-        return User.create(new UserCreateCommand(email, "encoded", "테스트", null));
+        return User.create(new UserCreateCommand(email, "encoded", "테스트", null, null));
     }
 
     @Test

--- a/api/src/test/java/kr/ac/kyonggi/api/experience/ExperienceApiServiceTest.java
+++ b/api/src/test/java/kr/ac/kyonggi/api/experience/ExperienceApiServiceTest.java
@@ -60,7 +60,7 @@ class ExperienceApiServiceTest {
 
     @BeforeEach
     void setUp() {
-        user = User.create(new UserCreateCommand(EMAIL, "pw", "홍길동", null));
+        user = User.create(new UserCreateCommand(EMAIL, "pw", "홍길동", null, null));
         ReflectionTestUtils.setField(user, "id", USER_ID);
 
         project = Project.create(new ProjectCreateCommand("프로젝트 제목", "설명", "카테고리", List.of("Java"), 5, null, USER_ID));
@@ -180,7 +180,7 @@ class ExperienceApiServiceTest {
     @Test
     @DisplayName("startSummarize()는 본인 경험이 아니면 ForbiddenException을 던진다")
     void startSummarize_throwsForbiddenException_forNonOwner() {
-        User other = User.create(new UserCreateCommand("other@test.com", "pw", "타인", null));
+        User other = User.create(new UserCreateCommand("other@test.com", "pw", "타인", null, null));
         ReflectionTestUtils.setField(other, "id", 99L);
 
         given(userService.getByEmail("other@test.com")).willReturn(other);

--- a/api/src/test/java/kr/ac/kyonggi/api/notification/NotificationApiServiceTest.java
+++ b/api/src/test/java/kr/ac/kyonggi/api/notification/NotificationApiServiceTest.java
@@ -40,7 +40,7 @@ class NotificationApiServiceTest {
 
     @BeforeEach
     void setUp() {
-        user = User.create(new UserCreateCommand("test@test.com", "pw", "홍길동", null));
+        user = User.create(new UserCreateCommand("test@test.com", "pw", "홍길동", null, null));
         ReflectionTestUtils.setField(user, "id", 1L);
 
         notification = Notification.create(new NotificationCreateCommand(1L, "\"테스트\" 프로젝트에 참가했습니다."));

--- a/api/src/test/java/kr/ac/kyonggi/api/project/ParticipantResponseTest.java
+++ b/api/src/test/java/kr/ac/kyonggi/api/project/ParticipantResponseTest.java
@@ -1,0 +1,42 @@
+package kr.ac.kyonggi.api.project;
+
+import kr.ac.kyonggi.api.project.dto.ParticipantResponse;
+import kr.ac.kyonggi.domain.project.ProjectMember;
+import kr.ac.kyonggi.domain.project.ProjectMemberCreateCommand;
+import kr.ac.kyonggi.domain.user.User;
+import kr.ac.kyonggi.domain.user.UserCreateCommand;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ParticipantResponseTest {
+
+    @Test
+    @DisplayName("ParticipantResponse.of()는 User의 email과 phone을 포함해야 한다")
+    void of_includesEmailAndPhone() {
+        User user = User.create(new UserCreateCommand("test@example.com", "pw", "홍길동", null));
+        ReflectionTestUtils.setField(user, "phone", "010-1234-5678");
+
+        ProjectMember member = ProjectMember.of(new ProjectMemberCreateCommand(1L, 1L));
+
+        ParticipantResponse response = ParticipantResponse.of(user, member);
+
+        assertThat(response.email()).isEqualTo("test@example.com");
+        assertThat(response.phone()).isEqualTo("010-1234-5678");
+    }
+
+    @Test
+    @DisplayName("ParticipantResponse.of()는 phone이 null이어도 정상 동작한다")
+    void of_phoneNullIsAllowed() {
+        User user = User.create(new UserCreateCommand("test@example.com", "pw", "홍길동", null));
+
+        ProjectMember member = ProjectMember.of(new ProjectMemberCreateCommand(1L, 1L));
+
+        ParticipantResponse response = ParticipantResponse.of(user, member);
+
+        assertThat(response.email()).isEqualTo("test@example.com");
+        assertThat(response.phone()).isNull();
+    }
+}

--- a/api/src/test/java/kr/ac/kyonggi/api/project/ParticipantResponseTest.java
+++ b/api/src/test/java/kr/ac/kyonggi/api/project/ParticipantResponseTest.java
@@ -16,7 +16,7 @@ class ParticipantResponseTest {
     @Test
     @DisplayName("ParticipantResponse.of()는 User의 email과 phone을 포함해야 한다")
     void of_includesEmailAndPhone() {
-        User user = User.create(new UserCreateCommand("test@example.com", "pw", "홍길동", null));
+        User user = User.create(new UserCreateCommand("test@example.com", "pw", "홍길동", null, null));
         ReflectionTestUtils.setField(user, "phone", "010-1234-5678");
 
         ProjectMember member = ProjectMember.of(new ProjectMemberCreateCommand(1L, 1L));
@@ -30,7 +30,7 @@ class ParticipantResponseTest {
     @Test
     @DisplayName("ParticipantResponse.of()는 phone이 null이어도 정상 동작한다")
     void of_phoneNullIsAllowed() {
-        User user = User.create(new UserCreateCommand("test@example.com", "pw", "홍길동", null));
+        User user = User.create(new UserCreateCommand("test@example.com", "pw", "홍길동", null, null));
 
         ProjectMember member = ProjectMember.of(new ProjectMemberCreateCommand(1L, 1L));
 

--- a/api/src/test/java/kr/ac/kyonggi/api/project/ProjectMemberRepositoryTest.java
+++ b/api/src/test/java/kr/ac/kyonggi/api/project/ProjectMemberRepositoryTest.java
@@ -39,8 +39,8 @@ class ProjectMemberRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        user1 = em.persist(User.create(new UserCreateCommand("user1@test.com", "pw", "유저1", null)));
-        user2 = em.persist(User.create(new UserCreateCommand("user2@test.com", "pw", "유저2", null)));
+        user1 = em.persist(User.create(new UserCreateCommand("user1@test.com", "pw", "유저1", null, null)));
+        user2 = em.persist(User.create(new UserCreateCommand("user2@test.com", "pw", "유저2", null, null)));
         project = em.persist(Project.create(new ProjectCreateCommand(
                 "테스트 프로젝트", "설명", "백엔드",
                 List.of("Java"), 4, LocalDate.of(2026, 12, 31), user1.getId()

--- a/api/src/test/java/kr/ac/kyonggi/api/project/ProjectRepositoryTest.java
+++ b/api/src/test/java/kr/ac/kyonggi/api/project/ProjectRepositoryTest.java
@@ -37,7 +37,7 @@ class ProjectRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        author = em.persist(User.create(new UserCreateCommand("author@test.com", "pw", "작성자", null)));
+        author = em.persist(User.create(new UserCreateCommand("author@test.com", "pw", "작성자", null, null)));
         em.flush();
     }
 

--- a/api/src/test/java/kr/ac/kyonggi/api/resume/ResumeApiServiceTest.java
+++ b/api/src/test/java/kr/ac/kyonggi/api/resume/ResumeApiServiceTest.java
@@ -64,7 +64,7 @@ class ResumeApiServiceTest {
 
     @BeforeEach
     void setUp() {
-        user = User.create(new UserCreateCommand(EMAIL, "pw", "홍길동", null));
+        user = User.create(new UserCreateCommand(EMAIL, "pw", "홍길동", null, null));
         ReflectionTestUtils.setField(user, "id", USER_ID);
 
         project = Project.create(new ProjectCreateCommand(

--- a/domain/src/main/java/kr/ac/kyonggi/domain/user/User.java
+++ b/domain/src/main/java/kr/ac/kyonggi/domain/user/User.java
@@ -56,6 +56,7 @@ public class User {
         this.password = command.password();
         this.name = command.name();
         this.profileImage = command.profileImage();
+        this.phone = command.phone();
     }
 
     public void updateProfile(UpdateProfileCommand command) {

--- a/domain/src/main/java/kr/ac/kyonggi/domain/user/UserCreateCommand.java
+++ b/domain/src/main/java/kr/ac/kyonggi/domain/user/UserCreateCommand.java
@@ -4,7 +4,8 @@ public record UserCreateCommand(
         String email,
         String password,
         String name,
-        String profileImage
+        String profileImage,
+        String phone
 ) {
 
 }


### PR DESCRIPTION
 ## 원인                                                                                                                                                               
                                                                                                                                                                        
  - `ParticipantResponse` DTO에 `email`, `phone` 필드가 누락되어 프로젝트 참가 멤버 조회 시 연락처 정보가 응답에 포함되지 않았습니다.
  - `RegisterRequest`에 `phone` 필드가 없어 회원가입 시 전화번호를 입력할 수 없었습니다.

  ## 변경 사항

  - `ParticipantResponse`에 `email`, `phone` 필드 추가
  - `RegisterRequest`에 `phone` 필드 추가 (선택값)
  - `UserCreateCommand`, `User` 생성자에 `phone` 반영
  - `.gitignore`에 로그 디렉토리(`**/logs/`) 추가
  - 관련 테스트 수정

  ## 테스트

  - [x] `ParticipantResponseTest` 통과
  - [x] `AuthControllerTest`, `AuthApiServiceTest` 통과
  - [x] 전체 테스트 통과 (`./gradlew test`)
  - [x] 로컬에서 실제 동작 확인

 closes #83 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자 등록 시 전화번호 정보 수집 기능 추가
  * 프로젝트 참가자 정보에 이메일 및 전화번호 표시 기능 추가

* **Tests**
  * 전화번호 관련 기능을 검증하는 테스트 케이스 추가 및 기존 테스트 업데이트

* **Chores**
  * 로그 파일 디렉터리를 무시 목록에 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->